### PR TITLE
Mock GP works, but hangs when no input change (io.BufferedReader clas…

### DIFF
--- a/ros/README.md
+++ b/ros/README.md
@@ -1,0 +1,9 @@
+`ROS_MASTER_URI` and `ROS_IP` both need to be set on the surface laptop at runtime, while the `ros/src/can_com/scripts/` folder must have either the virtual or real CAN startup scripts run to allow the `can_proc` nodes to run and not fail.
+
+`ROS_IP` is the IP address of the laptop's ethernet port connection, which you should be able to find using `ifconfig` on a terminal on Ubuntu/Linux
+
+`ROS_MASTER_URI` needs to be set using the export command that shows when you first boot into one of the pre-flashed SD cards (1 or 2, NOT 3), though roscore should have the URI print out during its process if you run it manually.
+
+If it's not, and you use the command that forwards the text printout to a log file (has `&`'s in it, will print when you log into the Pi if ROSCORE isn't already running), view the log file for the command. It should be of a format of `http://<pi's address>:11311`
+
+You may also find it's slightly more reliable to get ROS launched first on the Pi, and then on the laptop, but difinitive testing on that hasn't been made/consistent just yet. Try that if you have issues.

--- a/ros/launch/run_msurface.launch
+++ b/ros/launch/run_msurface.launch
@@ -1,0 +1,6 @@
+<launch>
+    <group ns="surface">
+        <node name="mock_gp" pkg="mux_demux" type="driver_mocker.py" />
+        <node name="mock_mux" pkg="mux_demux" type="mock_propigate.py" />
+    </group>
+</launch>

--- a/ros/src/mux_demux/scripts/driver_mocker.py
+++ b/ros/src/mux_demux/scripts/driver_mocker.py
@@ -1,0 +1,103 @@
+#! /usr/bin/python
+import rospy
+from shared_msgs.msg import can_msg, auto_command_msg, thrust_status_msg, thrust_command_msg, esc_single_msg
+from sensor_msgs.msg import Imu, Temperature
+from std_msgs.msg import Float32
+
+from inputs import get_gamepad, devices, iter_unpack
+import os
+
+def thrust_status_received(msg):
+  pass # This runs on a seperate thread
+def esc_single_received(msg):
+  pass # This runs on a seperate thread
+
+def temp_received(msg):
+  pass # This runs on a seperate thread
+def imu_received(msg):
+  pass # This runs on a seperate thread
+def ph_received(msg):
+  pass # This runs on a seperate thread
+def depth_received(msg):
+  pass # This runs on a seperate thread
+
+if __name__ == "__main__":
+
+    rospy.init_node('driver_mocker')
+    ns = rospy.get_namespace() # This should return /surface
+    
+
+    # Retrieve data from the ROS System
+    esc_sub = rospy.Subscriber('/rov/esc_single', 
+        esc_single_msg, esc_single_received)
+
+    status_sub = rospy.Subscriber('/rov/thrust_status',thrust_status_msg,
+        thrust_status_received);
+
+    temp_sub = rospy.Subscriber('/rov/temp', Temperature,
+        temp_received);
+
+    imu_sub = rospy.Subscriber('/rov/imu', Imu,
+        imu_received);
+
+    ph_sub = rospy.Subscriber('/rov/ph',Float32,
+        ph_received);
+
+    depth_sub = rospy.Subscriber('/rov/depth', Float32,
+        depth_received);
+
+    # Publishers out onto the ROS System
+    thrust_pub = rospy.Publisher(ns + 'thrust_mock',
+        thrust_command_msg, queue_size=10);
+
+    auto_pub= rospy.Publisher(ns +'auto_command',
+        auto_command_msg, queue_size=10);
+    
+    out = thrust_command_msg()
+    
+    keys = {
+            'BTN_TR': {"indx": 3, "weight": .5, "scale": 1.0},
+            'BTN_TL': {"indx": 3, "weight": -.5, "scale": 1.0},
+            'ABS_RY': {"indx": 4, "weight": .5, "scale": 32768.0},
+            'ABS_RX': {"indx": 5, "weight": .5, "scale": 32768.0},
+            'ABS_RZ': {"indx": 2, "weight": .5, "scale": 1024.0},
+            'ABS_X': {"indx": 0, "weight": .5, "scale": 32768.0},
+            'ABS_Y': {"indx": 1, "weight": .5, "scale": 32768.0},
+            'ABS_Z': {"indx": 2, "weight": -.5, "scale": 1024.0}
+    }
+
+    rate = rospy.Rate(1000) # 10hz
+
+    # TODO: I2C related activities
+    while not rospy.is_shutdown():
+        ## I tried to make this dynamic and read only if there was information
+        ## present, but through the nature of the underlying C(?) code it was
+        ## not possible
+        # catch up on events since last run, update the desired thrust values
+        gamepad = get_gamepad()
+        for event in gamepad:
+            press = event.code
+
+            if press in keys:
+                alt = keys[press]
+
+                val = event.state / alt["scale"]
+                if press == "BTN_TR":
+                    print(val)
+                    if not event.state and out.desired_thrust[alt["indx"]] < 0:
+                        val = out.desired_thrust[alt["indx"]]
+                elif press == "BTN_TL":
+                    print(val)
+                    if not event.state and out.desired_thrust[alt["indx"]] > 0:
+                        val = out.desired_thrust[alt["indx"]]
+                
+                if abs(val) < 0.1:
+                    val = 0
+
+                out.desired_thrust[alt["indx"]] = alt["weight"] * val
+
+        print(out.desired_thrust)
+
+        thrust_pub.publish(out)
+        auto_pub.publish(auto_command_msg())
+        rate.sleep()

--- a/ros/src/mux_demux/scripts/driver_mocker.py
+++ b/ros/src/mux_demux/scripts/driver_mocker.py
@@ -32,26 +32,26 @@ if __name__ == "__main__":
         esc_single_msg, esc_single_received)
 
     status_sub = rospy.Subscriber('/rov/thrust_status',thrust_status_msg,
-        thrust_status_received);
+        thrust_status_received)
 
     temp_sub = rospy.Subscriber('/rov/temp', Temperature,
-        temp_received);
+        temp_received)
 
     imu_sub = rospy.Subscriber('/rov/imu', Imu,
-        imu_received);
+        imu_received)
 
     ph_sub = rospy.Subscriber('/rov/ph',Float32,
-        ph_received);
+        ph_received)
 
     depth_sub = rospy.Subscriber('/rov/depth', Float32,
-        depth_received);
+        depth_received)
 
     # Publishers out onto the ROS System
     thrust_pub = rospy.Publisher(ns + 'thrust_mock',
-        thrust_command_msg, queue_size=10);
+        thrust_command_msg, queue_size=10)
 
     auto_pub= rospy.Publisher(ns +'auto_command',
-        auto_command_msg, queue_size=10);
+        auto_command_msg, queue_size=10)
     
     out = thrust_command_msg()
     

--- a/ros/src/mux_demux/scripts/gp_params_inputs.json
+++ b/ros/src/mux_demux/scripts/gp_params_inputs.json
@@ -1,0 +1,101 @@
+{
+    "axis": {
+        "ABS_HAT0X": {
+            "max": 1, 
+            "min": -1, 
+            "val": 0
+        }, 
+        "ABS_HAT0Y": {
+            "max": 1, 
+            "min": -1, 
+            "val": 0
+        }, 
+        "ABS_RX": {
+            "max": 32767, 
+            "min": -32768, 
+            "val": 330
+        }, 
+        "ABS_RY": {
+            "max": 32767, 
+            "min": -32768, 
+            "val": -1
+        }, 
+        "ABS_RZ": {
+            "max": 1023, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "ABS_X": {
+            "max": 32767, 
+            "min": -32768, 
+            "val": 0
+        }, 
+        "ABS_Y": {
+            "max": 32767, 
+            "min": -32768, 
+            "val": -1
+        }, 
+        "ABS_Z": {
+            "max": 1023, 
+            "min": 0, 
+            "val": 0
+        }
+    }, 
+    "bttn": {
+        "BTN_EAST": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_MODE": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_NORTH": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_SELECT": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_SOUTH": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_START": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_THUMBL": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_THUMBR": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_TL": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_TR": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }, 
+        "BTN_WEST": {
+            "max": 1, 
+            "min": 0, 
+            "val": 0
+        }
+    }
+}

--- a/ros/src/mux_demux/scripts/inputs_driver_readings.py
+++ b/ros/src/mux_demux/scripts/inputs_driver_readings.py
@@ -1,0 +1,58 @@
+"""Simple example showing how to get gamepad events."""
+
+from inputs import get_gamepad
+import signal
+import json
+import sys
+
+def interrupt_handler(bttn, axis, fileout="gp_params.json"):
+    def signal_handler(sig, frame):
+        print("Ctrl+C sensed!")
+
+        with open(fileout, "w") as fp:
+            fp.write(json.dumps({"bttn": bttn, "axis": axis}, indent=4, sort_keys=True))
+
+        print("File written, closing")
+        sys.exit(0)
+    
+    return signal_handler
+
+def main():
+    """Just print out some event infomation when the gamepad is used."""
+    bttn = {}
+    axis = {}
+
+    # signal.signal(signal.SIGINT, interrupt_handler(bttn, axis))
+
+    while 1:
+        events = get_gamepad()
+        for event in events:
+            print(event.ev_type, event.code, event.state)
+
+            if event.ev_type == "Absolute":
+                if event.code not in axis:
+                    axis[event.code] = {"val": 0, "max": 0, "min": 0}
+                
+                axis[event.code]["val"] = event.state
+                
+                if event.state > axis[event.code]["max"]:
+                    axis[event.code]["max"] = event.state
+                
+                if event.state < axis[event.code]["min"]:
+                    axis[event.code]["min"] = event.state
+
+            elif event.ev_type == "Key":
+                if event.code not in bttn:
+                    bttn[event.code] = {"val": 0, "max": 0, "min": 0}
+                
+                bttn[event.code]["val"] = event.state
+                
+                if event.state > bttn[event.code]["max"]:
+                    bttn[event.code]["max"] = event.state
+                
+                if event.state < bttn[event.code]["min"]:
+                    bttn[event.code]["min"] = event.state
+
+
+if __name__ == "__main__":
+    main()

--- a/ros/src/mux_demux/scripts/mock_propigate.py
+++ b/ros/src/mux_demux/scripts/mock_propigate.py
@@ -1,0 +1,32 @@
+#! /usr/bin/python
+import rospy
+from shared_msgs.msg import can_msg, auto_command_msg, thrust_status_msg, thrust_command_msg, esc_single_msg
+from sensor_msgs.msg import Imu, Temperature
+from std_msgs.msg import Float32
+
+import random
+
+mock = thrust_command_msg()
+
+def mock_catch(msg):
+  global mock
+  mock = msg
+
+if __name__ == "__main__":
+    rospy.init_node('mock_prop')
+    ns = rospy.get_namespace() # This should return /surface
+
+    status_sub = rospy.Subscriber(ns + 'thrust_mock',
+        thrust_command_msg, mock_catch)
+
+    # Publishers out onto the ROS System
+    thrust_pub = rospy.Publisher(ns + 'thrust_command',
+      thrust_command_msg, queue_size=10)
+
+    rate = rospy.Rate(10) # 10hz
+    # TODO: I2C related activities
+    while not rospy.is_shutdown():
+      thrust_pub.publish(mock)
+      rate.sleep()
+      
+


### PR DESCRIPTION
Mock gamepad component works

Only caveat is that it hangs when there's no input change

I mitigated this by putting a mocker and propigator through together, the mocker hangs but the propigator updates regularly (and doesn't lag from the mocker).

But, if you `rosnode kill -a` or Ctrl+C, you may have to press a gamepad button or move a joystick to un-hang the propigator node and let it die. Joysticks being slightly off center will let it pass, but doesn't always happen.

Other than that, Ian tested, Ian approved. Does a 10% --> 0 limiting on all values as well.

Will serve our means for a pool test, could work to drive in general fairly well.